### PR TITLE
fix: use more ubiquitous sha256sum over sha256

### DIFF
--- a/examples/internet-gateway/main.tf
+++ b/examples/internet-gateway/main.tf
@@ -10,7 +10,7 @@ locals {
   firezone_token = "<YOUR TOKEN HERE>"
 
   # We recommend a minimum of 3 instances for high availability.
-  gateway_count = 4
+  gateway_count = 3
 
   # Whether to attach Elastic IPs to the Gateway instances. Set to false to restrict the Gateways
   # to private subnets only. Note: using only private subnets for the Gateway will require a NAT in a public subnet.

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "gateway" {
   FIREZONE_TOKEN="${var.firezone_token}" \
   FIREZONE_VERSION="${var.firezone_version}" \
   FIREZONE_NAME="${var.firezone_name}" \
-  FIREZONE_ID="$(head -c /dev/urandom | sha256)" \
+  FIREZONE_ID="$(head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1)" \
   FIREZONE_API_URL="${var.firezone_api_url}" \
   bash <(curl -fsSL https://raw.githubusercontent.com/firezone/firezone/main/scripts/gateway-systemd-install.sh)
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "base_ami" {
-  description = "The base AMI for the instances"
+  description = "The base AMI for the instances. This module assumes a Debian-based AMI."
   type        = string
 }
 


### PR DESCRIPTION
`sha256sum` is on every Linux platform, not sha256 itself.

Fixes #9 