### PR TITLE
feat: update module to use single-owner gateway tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,140 @@
-# Firezone Terraform modules and examples for AWS
+# Firezone Gateway module for AWS
 
-This repo contains Terraform modules to use for Firezone deployments on AWS.
+Deploys one or more [Firezone](https://www.firezone.dev) Gateways as EC2
+instances in an existing VPC. Each instance installs the Gateway on first boot
+using the official
+[systemd install script](https://github.com/firezone/firezone/blob/main/scripts/gateway-systemd-install.sh)
+and registers itself with your Firezone account.
+
+## Prerequisites
+
+- A Firezone account with a Site to deploy Gateways into. Generate deploy
+  tokens from the admin portal under **Sites → \<site\> → Deploy Gateway**.
+- An existing VPC with a subnet for the instances and egress to the internet
+  (Internet Gateway or NAT) so the Gateways can reach the Firezone API.
+- A Debian-based AMI (Ubuntu LTS recommended) — the install step uses
+  `apt-get`.
+
+## Usage
+
+```hcl
+module "gateway" {
+  source = "firezone/gateway/aws"
+
+  # One single-owner token per Gateway instance; one instance is deployed
+  # per token.
+  firezone_tokens = var.firezone_tokens
+
+  base_ami          = data.aws_ami_ids.ubuntu.ids[0]
+  availability_zone = "us-east-1a"
+
+  vpc                      = aws_vpc.main.id
+  private_subnet           = aws_subnet.private.id
+  instance_security_groups = [aws_security_group.instance.id]
+}
+```
+
+See [examples/internet-gateway](./examples/internet-gateway) for a complete
+working example including the VPC, routing, security groups, and Elastic IPs.
+
+### Legacy: multi-owner token
+
+Multi-owner tokens are considered legacy and should only be used for existing
+deployments. A single token is shared by every Gateway instance, and the
+instance count is set with `replicas`:
+
+```hcl
+module "gateway" {
+  source = "firezone/gateway/aws"
+
+  # A single multi-owner token shared by all Gateway instances (legacy).
+  firezone_token = var.firezone_token
+  replicas       = 3
+
+  base_ami          = data.aws_ami_ids.ubuntu.ids[0]
+  availability_zone = "us-east-1a"
+
+  vpc                      = aws_vpc.main.id
+  private_subnet           = aws_subnet.private.id
+  instance_security_groups = [aws_security_group.instance.id]
+}
+```
+
+## Token modes
+
+The module supports both Firezone token types. Set exactly one of the two
+variables:
+
+| Mode | Variable | Behavior |
+|------|----------|----------|
+| Single-owner (default) | `firezone_tokens` | One token per instance; one Gateway instance is deployed per token in the list. Each token can only be used by one connected Gateway at a time. |
+| Multi-owner (legacy) | `firezone_token` | A single token shared by every Gateway instance in the cluster; the instance count is set with `replicas`. |
+
+Single-owner tokens are the default way to deploy Gateways. Multi-owner tokens
+are considered legacy and are supported for existing deployments only; new
+deployments should use single-owner tokens.
+
+With single-owner tokens, the number of Gateway instances is determined by the
+length of the token list — to scale up, append tokens; to scale down, remove
+tokens from the end. Do not set `replicas` in this mode. Tokens are assigned
+to instances by list position: `firezone_tokens[0]` goes to instance `0`, and
+so on. A single-owner token can be reused by a replacement instance once the
+previous Gateway using it has disconnected from the portal. When changing the
+list, replace tokens in place rather than removing entries from the middle —
+removing a middle entry shifts every token after it to a different instance
+and forces those instances to be replaced.
+
+## High availability
+
+Deploy at least 3 replicas for high availability. Gateways in the same Site
+automatically load-balance and fail over. See the
+[Gateway deployment docs](https://www.firezone.dev/kb/deploy/gateways) for
+sizing and architecture recommendations.
+
+## Upgrading and instance replacement
+
+The Firezone token and other settings are passed via `user_data`, so changing
+`firezone_version`, tokens, or logging settings **replaces the instances**.
+This is safe for connectivity as long as other Gateways in the Site remain
+online, but plan for it in production: Terraform may replace all instances in
+parallel. Pinning `firezone_version`
+(rather than `latest`) keeps replacements reproducible.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `base_ami` | The base AMI for the instances. This module assumes a Debian-based AMI. | `string` | n/a | yes |
+| `availability_zone` | The availability zone to deploy the instances in. | `string` | n/a | yes |
+| `vpc` | The VPC id to use. | `string` | n/a | yes |
+| `private_subnet` | The private subnet id. | `string` | n/a | yes |
+| `instance_security_groups` | The security group ids to attach to the instances. | `list(string)` | n/a | yes |
+| `firezone_tokens` | A list of single-owner Firezone tokens, one per Gateway instance. One instance is deployed per token. Mutually exclusive with `firezone_token`. | `list(string)` | `null` | one of |
+| `firezone_token` | A multi-owner Firezone token shared by all Gateway instances (legacy). Mutually exclusive with `firezone_tokens`. | `string` | `null` | one of |
+| `replicas` | The number of Gateway instances to deploy when using `firezone_token` (legacy). Must not be set with `firezone_tokens`. | `number` | `3` | no |
+| `instance_type` | The instance type. Gateways are lightweight; see [sizing recommendations](https://www.firezone.dev/kb/deploy/gateways#sizing-recommendations). | `string` | `"t3.nano"` | no |
+| `firezone_version` | The Gateway version to deploy. | `string` | `"latest"` | no |
+| `firezone_name` | Name for the Gateways, appears in the admin portal. | `string` | `"$(hostname)"` | no |
+| `firezone_api_url` | The Firezone API URL. | `string` | `"wss://api.firezone.dev"` | no |
+| `attach_public_ips` | Whether to attach public IPs to the instances. | `bool` | `true` | no |
+| `aws_eip_ids` | Elastic IP ids to attach to the instances. Must be the same length as `replicas` if provided. | `list(string)` | `[]` | no |
+| `log_level` | Sets `RUST_LOG` for the Gateway process. | `string` | `"info"` | no |
+| `log_format` | Sets `FIREZONE_LOG_FORMAT`. Either `human` or `json`. | `string` | `"human"` | no |
+| `enable_flow_logs` | Sets `FIREZONE_FLOW_LOGS=true` for the Gateway when enabled. | `bool` | `false` | no |
+| `extra_tags` | Extra tags for the instances. | `map(string)` | `{}` | no |
+
+## Outputs
+
+This module currently exposes no outputs.
 
 ## Examples
 
-- [Internet Gateway](./examples/internet-gateway): This example shows how to
-  deploy one or more Firezone Gateways in a single AWS VPC that is configured
-  with an Internet Gateway for egress. The Gateways will be associated to
-  dedicated Elastic IP Resources to minimize IP churn. Read this if you're
-  looking to deploy Firezone Gateways to AWS that need to communicate with the
-  internet using static IPs.
+- [Internet Gateway](./examples/internet-gateway): Deploy one or more Firezone
+  Gateways in a single AWS VPC configured with an Internet Gateway for egress.
+  The Gateways are associated with dedicated Elastic IPs to minimize IP churn.
+  Read this if you're looking to deploy Firezone Gateways to AWS that need to
+  communicate with the internet using static IPs.
+
+## License
+
+See [LICENSE](./LICENSE).

--- a/examples/internet-gateway/main.tf
+++ b/examples/internet-gateway/main.tf
@@ -6,11 +6,14 @@ locals {
   # The availability zone to deploy the Gateway instances in.
   availability_zone = "us-east-1a"
 
-  # Generate a token from the admin portal in Sites -> <site> -> Deploy Gateway.
-  firezone_token = "<YOUR TOKEN HERE>"
+  # Generate one single-owner token per Gateway instance from the admin portal
+  # in Sites -> <site> -> Deploy Gateway. One Gateway instance is deployed per
+  # token. We recommend a minimum of 3 instances for high availability.
+  firezone_tokens = ["<TOKEN 1>", "<TOKEN 2>", "<TOKEN 3>"]
 
-  # We recommend a minimum of 3 instances for high availability.
-  gateway_count = 3
+  # Used to create Elastic IPs for the Gateway instances.
+  # One Gateway instance is deployed per token.
+  gateway_count = length(local.firezone_tokens)
 
   # Whether to attach Elastic IPs to the Gateway instances. Set to false to restrict the Gateways
   # to private subnets only. Note: using only private subnets for the Gateway will require a NAT in a public subnet.
@@ -24,9 +27,15 @@ module "gateway" {
   # Required inputs #
   ###################
 
-  # Generate a token from the admin portal in Sites -> <site> -> Deploy Gateway.
-  # Only one token is needed for the cluster.
-  firezone_token = local.firezone_token
+  # Single-owner tokens, one per Gateway instance (bound to one connected
+  # Gateway at a time). The list length must match the number of replicas.
+  firezone_tokens = local.firezone_tokens
+
+  # Legacy: multi-owner tokens share one token across the cluster. Only use
+  # this for existing deployments; set it instead of firezone_tokens and set
+  # replicas to the desired number of instances.
+  # firezone_token = "<YOUR TOKEN HERE>"
+  # replicas       = 3
 
   # Pick an AMI to use. We recommend Ubuntu LTS or Amazon Linux 2.
   base_ami = data.aws_ami_ids.ubuntu.ids[0]
@@ -42,11 +51,8 @@ module "gateway" {
   # Optional inputs #
   ###################
 
-  # Attach existing Elastic IPs. Length must match the number of replicas if provided.
+  # Attach existing Elastic IPs. Length must match the number of Gateway instances if provided.
   aws_eip_ids = aws_eip.gateway[*].id
-
-  # We recommend a minimum of 3 instances for high availability.
-  replicas = local.gateway_count
 
   # Deploy a specific version of the Gateway. Generally, we recommend using the latest version.
   # firezone_version    = "latest"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,12 @@
+locals {
+  # In single-owner mode the instance count comes from the token list;
+  # in legacy multi-owner mode it comes from var.replicas (default 3).
+  replicas = var.firezone_tokens != null ? length(var.firezone_tokens) : coalesce(var.replicas, 3)
+}
+
 resource "aws_instance" "gateway" {
   availability_zone = var.availability_zone
-  count             = var.replicas
+  count             = local.replicas
   ami               = var.base_ami
   instance_type     = var.instance_type
   subnet_id         = var.private_subnet
@@ -18,7 +24,7 @@ resource "aws_instance" "gateway" {
   sudo apt-get update
   sudo apt-get install -y curl iptables
 
-  export FIREZONE_TOKEN="${var.firezone_token}"
+  export FIREZONE_TOKEN="${var.firezone_tokens != null ? var.firezone_tokens[count.index] : var.firezone_token}"
   export FIREZONE_VERSION="${var.firezone_version}"
   export FIREZONE_NAME="${var.firezone_name}"
   export FIREZONE_ID="$(head -c 32 /dev/urandom | sha256sum | cut -d' ' -f1)"
@@ -36,6 +42,18 @@ resource "aws_instance" "gateway" {
   tags = merge({
     Name = "firezone-gateway-instance"
   }, var.extra_tags)
+
+  lifecycle {
+    precondition {
+      condition     = (var.firezone_token != null) != (var.firezone_tokens != null)
+      error_message = "Exactly one of firezone_token (multi-owner) or firezone_tokens (single-owner, one per instance) must be set."
+    }
+
+    precondition {
+      condition     = var.firezone_tokens == null || var.replicas == null
+      error_message = "replicas cannot be set when firezone_tokens is used; the number of instances is determined by the length of the token list."
+    }
+  }
 }
 
 # Associate the Elastic IPs with the Gateway instances.
@@ -46,7 +64,7 @@ resource "aws_eip_association" "gateway" {
 
   lifecycle {
     precondition {
-      condition     = length(var.aws_eip_ids) == 0 || length(var.aws_eip_ids) == var.replicas
+      condition     = length(var.aws_eip_ids) == 0 || length(var.aws_eip_ids) == local.replicas
       error_message = "The number of EIPs must match the number of Gateway instances."
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -15,15 +15,22 @@ variable "availability_zone" {
 }
 
 variable "replicas" {
-  description = "The number of gateway instances to deploy"
+  description = "The number of gateway instances to deploy when using firezone_token (legacy). Defaults to 3. Must not be set when using firezone_tokens, where the number of instances is the length of the token list."
   type        = number
-  default     = 3
+  default     = null
 }
 
 variable "firezone_token" {
-  description = "The Firezone token"
+  description = "A multi-owner Firezone token shared by all Gateway instances (legacy). New deployments should use firezone_tokens instead. Mutually exclusive with firezone_tokens."
   type        = string
-  nullable    = false
+  default     = null
+  sensitive   = true
+}
+
+variable "firezone_tokens" {
+  description = "A list of single-owner Firezone tokens, one per Gateway instance. Each token can only be used by one connected Gateway at a time. The number of Gateway instances deployed is the length of this list. Mutually exclusive with firezone_token."
+  type        = list(string)
+  default     = null
   sensitive   = true
 }
 


### PR DESCRIPTION
Now that single-owner gateway tokens are about to be the default way to deploy gateways, the terraform module needed to be updated to allow for the use of both single-owner and multi-owner tokens.